### PR TITLE
Update ArduinoTcpHardware.h

### DIFF
--- a/src/ArduinoTcpHardware.h
+++ b/src/ArduinoTcpHardware.h
@@ -42,7 +42,7 @@
   #include <WiFi.h> // Using Espressif's WiFi.h
 #else
   #include <SPI.h>
-  #include <Ethernet.h>
+  #include <NativeEthernet.h>
 #endif
 
 class ArduinoHardware {


### PR DESCRIPTION
The Teensy doesn't use an Ethernet shield, instead using native Ethernet hardware build onto the board. <NativeEthernet.h> is a drop-in replacement for the standard Arduino <Ethernet.h>library that allows us to use this built-in hardware.